### PR TITLE
ci: replace setup-ffmpeg with local cached action

### DIFF
--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -35,6 +35,13 @@ runs:
         tar -xf /tmp/ffmpeg.tar.xz -C ~/.ffmpeg --strip-components=1
         rm /tmp/ffmpeg.tar.xz
 
+    - name: Save FFmpeg to cache
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.ffmpeg
+        key: ffmpeg-linux-amd64-${{ inputs.version }}
+
     - name: Add to PATH
       shell: bash
       run: echo "$HOME/.ffmpeg" >> $GITHUB_PATH

--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -4,7 +4,16 @@ description: Install FFmpeg with aggressive caching
 inputs:
   version:
     description: FFmpeg version (pin to avoid cache churn)
+    required: false
     default: '7.0.2'
+
+outputs:
+  version:
+    description: Installed FFmpeg version
+    value: ${{ inputs.version }}
+  path:
+    description: Path to FFmpeg binaries
+    value: ~/.ffmpeg
 
 runs:
   using: composite
@@ -14,7 +23,7 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.ffmpeg
-        key: ffmpeg-linux-amd64-${{ inputs.version }}
+        key: ffmpeg-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
 
     - name: Download FFmpeg
       if: steps.cache.outputs.cache-hit != 'true'
@@ -40,7 +49,7 @@ runs:
       uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.ffmpeg
-        key: ffmpeg-linux-amd64-${{ inputs.version }}
+        key: ffmpeg-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
 
     - name: Add to PATH
       shell: bash

--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -1,0 +1,44 @@
+name: Setup FFmpeg
+description: Install FFmpeg with aggressive caching
+
+inputs:
+  version:
+    description: FFmpeg version (pin to avoid cache churn)
+    default: '7.0.2'
+
+runs:
+  using: composite
+  steps:
+    - name: Restore FFmpeg from cache
+      id: cache
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.ffmpeg
+        key: ffmpeg-linux-amd64-${{ inputs.version }}
+
+    - name: Download FFmpeg
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -e
+        URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-${{ inputs.version }}-amd64-static.tar.xz"
+        echo "Downloading FFmpeg ${{ inputs.version }} from johnvansickle.com"
+
+        curl -fsSL \
+          --retry 5 \
+          --retry-delay 10 \
+          --retry-max-time 120 \
+          --connect-timeout 30 \
+          "$URL" -o /tmp/ffmpeg.tar.xz
+
+        mkdir -p ~/.ffmpeg
+        tar -xf /tmp/ffmpeg.tar.xz -C ~/.ffmpeg --strip-components=1
+        rm /tmp/ffmpeg.tar.xz
+
+    - name: Add to PATH
+      shell: bash
+      run: echo "$HOME/.ffmpeg" >> $GITHUB_PATH
+
+    - name: Verify installation
+      shell: bash
+      run: ffmpeg -version | head -1

--- a/.github/workflows/generate-podcast.yml
+++ b/.github/workflows/generate-podcast.yml
@@ -62,8 +62,7 @@ jobs:
             libxss1 libxtst6 lsb-release wget xdg-utils
 
       - name: Setup FFmpeg
-        # Forked this PR: https://github.com/federicocarboni/setup-ffmpeg/pull/23
-        uses: denolfe/setup-ffmpeg@3143b4f20b9b0e3097d86816e90ea33fef8fccf1 # retries
+        uses: ./.github/actions/setup-ffmpeg
 
       - name: Cache Puppeteer browser
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
## Overview

Replaces the `denolfe/setup-ffmpeg` fork with a local composite action that downloads and caches FFmpeg binaries.

## Key Changes

- **New local action `.github/actions/setup-ffmpeg`**
  - Downloads static FFmpeg binary from johnvansickle.com
  - Caches to `~/.ffmpeg` using `actions/cache`
  - Pins to version 7.0.2 for a stable cache key (avoids churn when upstream updates "release")

- **Aggressive retry and caching strategy**
  - 5 retries with 10s delay, 120s max retry time, 30s connect timeout
  - Cache persists across runs; download only happens on cache miss

## Design Decisions

The fork existed to add retry logic to `federicocarboni/setup-ffmpeg`, but was still failing intermittently due to johnvansickle.com network issues. Rather than maintain a Node.js action fork, a simple bash/curl composite action provides equivalent functionality with less complexity.

Pinning to a specific version (7.0.2) instead of "release" ensures the cache key stays stable. To update FFmpeg, bump the `version` input.
