### PR TITLE
feat: schedule episode release, bring cron forward

### DIFF
--- a/.github/workflows/generate-podcast.yml
+++ b/.github/workflows/generate-podcast.yml
@@ -28,7 +28,10 @@ on:
         type: boolean
 
   schedule:
-    - cron: '30 10 * * *' # 6:30am EST daily
+    # Fires early on purpose: GitHub cron is delayed 30min-3.5h (see issue #13).
+    # Episode release time is controlled by Transistor scheduled publish (6:30am ET),
+    # and 05:47 UTC lands the story snapshot in HN's settled overnight window.
+    - cron: '47 5 * * *'
 
 permissions:
   contents: read
@@ -104,6 +107,7 @@ jobs:
         env:
           SKIP_PUBLISH: ${{ github.event.inputs.skip_publish }}
           VIDEO: ${{ github.event.inputs.video || 'false' }}
+          SCHEDULED_RELEASE: ${{ github.event_name == 'schedule' }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ELEVEN_LABS_API_KEY: ${{ secrets.ELEVEN_LABS_API_KEY }}
           DEBUG: ${{ github.event.inputs.debug }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ Pattern categories handled:
 
 ## CI/CD
 
-GitHub Actions workflow runs daily at 6:30am EST via cron schedule (`generate-podcast.yml`). Workflow:
+GitHub Actions workflow runs daily via cron (`generate-podcast.yml`). The cron fires at 05:47 UTC — intentionally early because GitHub cron delivery is delayed and variable (see issue #13). Scheduled runs set `SCHEDULED_RELEASE=true`, which makes the episode upload use Transistor scheduled publish targeting 6:30am Eastern (DST-aware, computed in `src/utils/publishTime.ts`). Manual runs (workflow_dispatch or `--publish`) publish immediately. Workflow:
 1. Restores `cache/covered-stories` from GitHub Actions cache
 2. Runs `pnpm start` with env vars from secrets
 3. Publishes episode automatically (CI env var triggers publish)

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { initCacheDir, writeToCache } from '@/utils/cache.js'
 import { loadEnvIfExists } from '@/utils/env.js'
 import { initOutputDir } from '@/utils/initOutputDir.js'
 import { log } from '@/utils/log.js'
+import { getScheduledPublishTime } from '@/utils/publishTime.js'
 import { writeToFile } from '@/utils/writeToFile.js'
 import { generateVideo, generateYouTubeChapters } from '@/video/index.js'
 import { captureScreenshot } from '@/video/screenshots.js'
@@ -232,6 +233,8 @@ async function main() {
         audioFilePath: EPISODE_OUTPUT,
         title,
         showNotes,
+        // Cron runs release at a consistent 6:30am ET; manual runs publish immediately
+        publishAt: process.env.SCHEDULED_RELEASE === 'true' ? getScheduledPublishTime() : undefined,
       })
     } else {
       log.info('SKIPPING episode publish')

--- a/src/podcast.spec.ts
+++ b/src/podcast.spec.ts
@@ -94,6 +94,12 @@ describe('uploadPodcast publish behavior', () => {
     await expect(uploadPodcast(uploadArgs)).rejects.toThrow(/Failed to publish/)
   })
 
+  it('accepts immediate publish when the scheduled time has already passed', async () => {
+    mockTransistorApi(() => jsonResponse({ data: { attributes: { status: 'published' } } }))
+    const publishAt = new Date('2026-07-15T10:30:00.000Z')
+    await expect(uploadPodcast({ ...uploadArgs, publishAt })).resolves.toBeUndefined()
+  })
+
   it('throws when the returned status does not match the requested one', async () => {
     mockTransistorApi(() => jsonResponse({ data: { attributes: { status: 'draft' } } }))
     const publishAt = new Date('2026-07-15T10:30:00.000Z')

--- a/src/podcast.spec.ts
+++ b/src/podcast.spec.ts
@@ -1,0 +1,102 @@
+import type { Mock } from 'vitest'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { uploadPodcast } from '@/podcast.js'
+
+vi.mock('fs/promises', () => ({
+  default: { readFile: vi.fn().mockResolvedValue(Buffer.from('fake-audio')) },
+}))
+
+const jsonResponse = (body: unknown, ok = true, status = 200) => ({
+  ok,
+  status,
+  statusText: ok ? 'OK' : 'Unprocessable Entity',
+  json: async () => body,
+})
+
+/** Mocks authorize/upload/create; publish PATCH resolves via `publishResult`. */
+function mockTransistorApi(publishResult: (init: RequestInit) => unknown): Mock {
+  const fetchMock = vi.fn().mockImplementation((url: string, init: RequestInit) => {
+    if (url.includes('authorize_upload')) {
+      return Promise.resolve(
+        jsonResponse({
+          data: {
+            id: '1',
+            type: 'upload',
+            attributes: {
+              upload_url: 'https://upload.example.com/file',
+              audio_url: 'https://audio.example.com/file.mp3',
+              content_type: 'audio/mpeg',
+              expires_in: 600,
+            },
+          },
+        }),
+      )
+    }
+    if (url === 'https://upload.example.com/file') {
+      return Promise.resolve({ ok: true, status: 200 })
+    }
+    if (url.endsWith('/episodes')) {
+      return Promise.resolve(jsonResponse({ data: { id: '42' } }))
+    }
+    if (url.endsWith('/episodes/42/publish')) {
+      return Promise.resolve(publishResult(init))
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  global.fetch = fetchMock as unknown as typeof fetch
+  return fetchMock
+}
+
+const publishPatchBody = (fetchMock: Mock): Record<string, unknown> => {
+  const call = fetchMock.mock.calls.find(([url]) => (url as string).endsWith('/publish'))
+  expect(call).toBeDefined()
+  return JSON.parse((call?.[1] as RequestInit).body as string)
+}
+
+const uploadArgs = {
+  audioFilePath: '/tmp/output.mp3',
+  title: 'Test Episode',
+  showNotes: 'Notes',
+}
+
+describe('uploadPodcast publish behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.TRANSISTOR_API_KEY = 'test-key'
+  })
+
+  it('publishes immediately when publishAt is absent', async () => {
+    const fetchMock = mockTransistorApi(() =>
+      jsonResponse({ data: { attributes: { status: 'published' } } }),
+    )
+    await uploadPodcast(uploadArgs)
+    const body = publishPatchBody(fetchMock)
+    expect(body.episode).toEqual({ status: 'published' })
+  })
+
+  it('schedules with ISO published_at when publishAt is set', async () => {
+    const fetchMock = mockTransistorApi(() =>
+      jsonResponse({ data: { attributes: { status: 'scheduled' } } }),
+    )
+    const publishAt = new Date('2026-07-15T10:30:00.000Z')
+    await uploadPodcast({ ...uploadArgs, publishAt })
+    const body = publishPatchBody(fetchMock)
+    expect(body.episode).toEqual({
+      status: 'scheduled',
+      published_at: '2026-07-15T10:30:00.000Z',
+    })
+  })
+
+  it('throws when the publish PATCH returns non-OK', async () => {
+    mockTransistorApi(() => jsonResponse({ errors: ['bad'] }, false, 422))
+    await expect(uploadPodcast(uploadArgs)).rejects.toThrow(/Failed to publish/)
+  })
+
+  it('throws when the returned status does not match the requested one', async () => {
+    mockTransistorApi(() => jsonResponse({ data: { attributes: { status: 'draft' } } }))
+    const publishAt = new Date('2026-07-15T10:30:00.000Z')
+    await expect(uploadPodcast({ ...uploadArgs, publishAt })).rejects.toThrow(/Failed to publish/)
+  })
+})

--- a/src/podcast.ts
+++ b/src/podcast.ts
@@ -117,12 +117,16 @@ export async function uploadPodcast(args: {
     }),
   })
 
-  const publishJson = (await publishRes.json()) as {
-    data?: { attributes?: { status?: string } }
-  }
+  const publishJson = (await publishRes.json().catch(() => undefined)) as
+    | { data?: { attributes?: { status?: string } } }
+    | undefined
   const returnedStatus = publishJson?.data?.attributes?.status
 
-  if (!publishRes.ok || returnedStatus !== episodeUpdate.status) {
+  // Transistor publishes immediately if the scheduled time has already passed
+  const isPublishSuccess =
+    publishRes.ok && (returnedStatus === episodeUpdate.status || returnedStatus === 'published')
+
+  if (!isPublishSuccess) {
     throw new Error(
       `Failed to publish episode ${episodeId}: HTTP ${publishRes.status}, returned status: ${returnedStatus}`,
     )

--- a/src/podcast.ts
+++ b/src/podcast.ts
@@ -8,9 +8,11 @@ export async function uploadPodcast(args: {
   audioFilePath: string
   title: string
   showNotes: string
+  /** Release episode at this time via Transistor scheduled publish; omit to publish immediately */
+  publishAt?: Date
 }) {
   log.info('Uploading podcast...')
-  const { audioFilePath, title, showNotes } = args
+  const { audioFilePath, title, showNotes, publishAt } = args
 
   const apiKey = process.env.TRANSISTOR_API_KEY!
   const headers = {
@@ -97,23 +99,36 @@ export async function uploadPodcast(args: {
   }
   log.info(`Created episode with ID: ${episodeId}`)
 
-  // Publish episode
-  log.info(`Publishing episode...`)
-  await fetch(`${baseUrl}/episodes/${episodeId}/publish`, {
+  // Publish or schedule episode
+  const episodeUpdate: { status: string; published_at?: string } = publishAt
+    ? { status: 'scheduled', published_at: publishAt.toISOString() }
+    : { status: 'published' }
+
+  log.info(
+    publishAt ? `Scheduling episode for ${publishAt.toISOString()}...` : 'Publishing episode...',
+  )
+
+  const publishRes = await fetch(`${baseUrl}/episodes/${episodeId}/publish`, {
     method: 'PATCH',
     headers,
     body: JSON.stringify({
       id: episodeId,
-      episode: {
-        status: 'published',
-      },
+      episode: episodeUpdate,
     }),
-  }).then(res => {
-    log.info({ status: res.status })
-    return res.json()
   })
 
-  log.info(`Published episode with ID: ${episodeId}`)
+  const publishJson = (await publishRes.json()) as {
+    data?: { attributes?: { status?: string } }
+  }
+  const returnedStatus = publishJson?.data?.attributes?.status
+
+  if (!publishRes.ok || returnedStatus !== episodeUpdate.status) {
+    throw new Error(
+      `Failed to publish episode ${episodeId}: HTTP ${publishRes.status}, returned status: ${returnedStatus}`,
+    )
+  }
+
+  log.info(`Episode ${episodeId} ${returnedStatus}`)
 }
 
 type Episode = {

--- a/src/utils/publishTime.spec.ts
+++ b/src/utils/publishTime.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { getScheduledPublishTime } from '@/utils/publishTime.js'
+
+describe('getScheduledPublishTime', () => {
+  it('returns 10:30 UTC in summer (6:30am EDT)', () => {
+    const result = getScheduledPublishTime(new Date('2026-07-15T05:47:00Z'))
+    expect(result.toISOString()).toBe('2026-07-15T10:30:00.000Z')
+  })
+
+  it('returns 11:30 UTC in winter (6:30am EST)', () => {
+    const result = getScheduledPublishTime(new Date('2026-01-15T05:47:00Z'))
+    expect(result.toISOString()).toBe('2026-01-15T11:30:00.000Z')
+  })
+
+  it('handles the spring-forward day (2026-03-08, 2am skips to 3am)', () => {
+    // 05:47 UTC = 12:47am EST; 6:30am that morning is already EDT
+    const result = getScheduledPublishTime(new Date('2026-03-08T05:47:00Z'))
+    expect(result.toISOString()).toBe('2026-03-08T10:30:00.000Z')
+  })
+
+  it('handles the fall-back day (2026-11-01, 2am repeats to 1am)', () => {
+    // 05:47 UTC = 1:47am EDT; 6:30am that morning is EST
+    const result = getScheduledPublishTime(new Date('2026-11-01T05:47:00Z'))
+    expect(result.toISOString()).toBe('2026-11-01T11:30:00.000Z')
+  })
+
+  it('is in the future relative to an early-morning cron firing', () => {
+    const now = new Date('2026-07-15T05:47:00Z')
+    expect(getScheduledPublishTime(now).getTime()).toBeGreaterThan(now.getTime())
+  })
+})

--- a/src/utils/publishTime.ts
+++ b/src/utils/publishTime.ts
@@ -1,0 +1,54 @@
+const TIME_ZONE = 'America/New_York'
+const PUBLISH_HOUR = 6
+const PUBLISH_MINUTE = 30
+
+/**
+ * UTC instant of "today 6:30am America/New_York" for the Eastern calendar
+ * date of `now`. DST-aware; episodes release at a consistent local time.
+ */
+export function getScheduledPublishTime(now: Date = new Date()): Date {
+  // en-CA formats as YYYY-MM-DD
+  const [year, month, day] = new Intl.DateTimeFormat('en-CA', {
+    timeZone: TIME_ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+    .format(now)
+    .split('-')
+    .map(Number)
+
+  // Two-pass: guess the wall clock as UTC, then correct by the zone offset
+  // at that instant (re-resolved once so DST-transition days converge)
+  const wallClockAsUtc = Date.UTC(year, month - 1, day, PUBLISH_HOUR, PUBLISH_MINUTE)
+  let offsetMs = timeZoneOffsetMs(new Date(wallClockAsUtc))
+  offsetMs = timeZoneOffsetMs(new Date(wallClockAsUtc - offsetMs))
+  return new Date(wallClockAsUtc - offsetMs)
+}
+
+/** Offset of TIME_ZONE from UTC at `date` (negative for US Eastern). */
+function timeZoneOffsetMs(date: Date): number {
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat('en-US', {
+      timeZone: TIME_ZONE,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    })
+      .formatToParts(date)
+      .map(p => [p.type, p.value]),
+  )
+  const asUtc = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    Number(parts.hour) % 24,
+    Number(parts.minute),
+    Number(parts.second),
+  )
+  return asUtc - date.getTime()
+}


### PR DESCRIPTION
# Overview

GitHub Actions cron delivery has degraded from ~15 min late in February to ~106 min average in July (worst +3h36m), so episodes intended for 6:30am ET were publishing hours late and at unpredictable times. This PR moves the cron early and hands release timing to Transistor's scheduled publish, so episodes go live at exactly 6:30am Eastern year-round.

Closes #13

## Key Changes

#### Cron moved from 10:30 UTC to 05:47 UTC

Fires intentionally early because GitHub cron delay is variable. Accounts for the longest documented delay of 3.6hrs. 

A side benefit: the story snapshot lands in HN's settled overnight window (05:00-08:00 UTC), capturing the previous day's top stories with 12-18h of votes instead of a mid-morning mix of half-risen stories.

#### Transistor scheduled publish

`uploadPodcast()` accepts an optional `publishAt`. When set, the publish PATCH sends `status: scheduled` with an ISO `published_at` instead of publishing immediately. Verified against the live API that UTC ISO-8601 timestamps round-trip unchanged.

#### DST-aware publish time helper

`getScheduledPublishTime()` computes "today 6:30am America/New_York" using a two-pass `Intl.DateTimeFormat` offset resolution. No new dependencies. The old cron comment said 6:30am EST but drifted an hour across DST; this handles both transition days correctly (unit-tested).

#### Publish response verification

The publish PATCH response was previously ignored, so a failed publish still reported success. It now throws on non-OK responses or unexpected status, failing the CI run hours before air time instead of leaving an episode silently stuck in draft.

## Design Decisions

- **Workflow signals intent, code computes time.** The workflow sets `SCHEDULED_RELEASE: ${{ github.event_name == 'schedule' }}`; the timezone math lives in tested TypeScript rather than YAML. Manual runs (workflow_dispatch or `--publish`) keep publish-now behavior.
- **Fail-safe default.** The scheduled path activates only on the exact string `'true'`. Any plumbing mistake degrades to publish-now, never to an unpublished episode.
- **Late runs never slip a day.** If a cron run is delayed past 6:30am ET, Transistor publishes immediately with a backdated timestamp, and a returned `published` status is accepted as success when `scheduled` was requested.

## Overall Flow

```mermaid
sequenceDiagram
    participant GH as GitHub Actions (cron 05:47 UTC)
    participant App as pnpm start
    participant T as Transistor API

    GH->>App: run with SCHEDULED_RELEASE=true
    App->>App: generate episode (summaries, audio)
    App->>App: getScheduledPublishTime() = today 6:30am ET
    App->>T: upload audio + create episode
    App->>T: PATCH publish status=scheduled, published_at=6:30am ET
    T-->>App: status=scheduled (or published, if 6:30 already passed)
    Note over T: Episode releases at exactly 6:30am ET
```

Previously the PATCH sent `status: published` at whatever time the delayed cron run finished.

## References / Links

- [GitHub community discussion on cron delays](https://github.com/orgs/community/discussions/156282)
- [Transistor API docs](https://developers.transistor.fm/)
