### PR TITLE
fix: restore pause during intro

### DIFF
--- a/src/audio/adjustPronunciation.spec.ts
+++ b/src/audio/adjustPronunciation.spec.ts
@@ -117,4 +117,17 @@ describe('adjustPronunciation', () => {
   ])('converts version numbers to use "-point-": %s', (input, expected) => {
     expect(adjustPronunciation(input)).toBe(expected)
   })
+
+  test.each([
+    ['<break time="0.5s" />', '<break time="0.5s" />'],
+    ['<break time="1.5s" />', '<break time="1.5s" />'],
+  ])('preserves SSML break tags verbatim: %s', (input, expected) => {
+    expect(adjustPronunciation(input)).toBe(expected)
+  })
+
+  test('preserves break tag while still adjusting surrounding text', () => {
+    const input = 'Python 3.9 is out. <break time="0.5s" /> Let us dive in.'
+    const expected = 'Python 3-point-9 is out. <break time="0.5s" /> Let us dive in.'
+    expect(adjustPronunciation(input)).toBe(expected)
+  })
 })

--- a/src/audio/adjustPronunciation.ts
+++ b/src/audio/adjustPronunciation.ts
@@ -2,6 +2,16 @@
  * TTS has issues with specific terms and patterns. This function replaces them with phonetic alternatives.
  */
 export function adjustPronunciation(text: string): string {
+  // Preserve SSML break tags verbatim. The rules below would corrupt their
+  // decimal time values (e.g. `0.5s` -> `0-point-5s`), which ElevenLabs then
+  // silently drops. Split keeps the captured tags in the array at odd indices.
+  return text
+    .split(/(<break\b[^>]*?\/?>)/i)
+    .map((segment, i) => (i % 2 === 0 ? applyPronunciationRules(segment) : segment))
+    .join('')
+}
+
+function applyPronunciationRules(text: string): string {
   return (
     text
       .replace(/(?<=Source: )\S+\b/g, source => {


### PR DESCRIPTION
The version-number pronunciation rule was corrupting SSML break tags (markup that tells the TTS engine to insert a timed pause), so intro pauses never played. Pronunciation rules now skip break tags.

## Root Cause

The version-number rule matches any decimal, including the time value inside a break tag. `<break time="0.5s" />` was rewritten to `<break time="0-point-5s" />`. ElevenLabs treats `0-point-5s` as an invalid time value and silently drops the pause.

## Key Changes

- **Shield break tags from pronunciation rules**
  - `adjustPronunciation` splits the text on `<break .../>` tags before applying any rules. The captured tags land at odd array indices and pass through untouched, then rejoin the rewritten segments.
  - Extracted the existing replacement logic into `applyPronunciationRules`, applied only to the non-tag segments.

Resolves #15
